### PR TITLE
Delete config file during startup

### DIFF
--- a/buildrpm/ovirt-csi-driver-container-image.spec
+++ b/buildrpm/ovirt-csi-driver-container-image.spec
@@ -6,7 +6,7 @@
 
 %global app_name                ovirt-csi-driver
 %global app_version             4.20.0
-%global oracle_release_version  2
+%global oracle_release_version  3
 %global _buildhost              build-ol%{?oraclelinux}-%{?_arch}.oracle.com
 
 Name:           %{app_name}-container-image
@@ -43,6 +43,9 @@ podman save -o %{app_name}.tar %{docker_image}
 /usr/local/share/olcne/%{app_name}.tar
 
 %changelog
+* Tue Jun 24 2025 Paul Mackin <paul.mackin@oracle.com> - 4.20.0-3
+- Delete config file containing password.
+
 * Thu Mar 27 2025 Paul Mackin <paul.mackin@oracle.com> - 4.20.0-2
 - Initial fixes for both controller plugin and node plugin.
 

--- a/buildrpm/ovirt-csi-driver.spec
+++ b/buildrpm/ovirt-csi-driver.spec
@@ -6,7 +6,7 @@
 
 %global app_name                ovirt-csi-driver
 %global app_version             4.20.0
-%global oracle_release_version  2
+%global oracle_release_version  3
 %global _buildhost              build-ol%{?oraclelinux}-%{?_arch}.oracle.com
 
 Name:           %{app_name}
@@ -37,6 +37,9 @@ install -m 755 bin/%{app_name} %{buildroot}/%{app_name}
 /%{app_name}
 
 %changelog
+* Tue Jun 24 2025 Paul Mackin <paul.mackin@oracle.com> - 4.20.0-3
+- Delete config file containing password.
+
 * Thu Mar 27 2025 Paul Mackin <paul.mackin@oracle.com> - 4.20.0-2
 - Initial fixes for both controller plugin and node plugin.
 


### PR DESCRIPTION
Delete config file during startup.  It contains sensitive information that is only needed during initialization.

**Using old image - Config file exists**
```
ls /tmp/config
ovirt-config.yaml  ovirt-engine-ca.pem

bash-4.4# cat /tmp/config/ovirt-config.yaml 
ovirt_url: <myurl>
ovirt_username: <myuser>
ovirt_password: <mypw>
# set a valid path only if ca bundle has content
ovirt_cafile: /tmp/config/ovirt-engine-ca.pem
ovirt_insecure: false
bash-4.4# 

 kk exec -it -n ovirt-csi      ovirt-csi-node-plugin-5jpf6  bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
Defaulted container "ovirt" out of: ovirt, liveness-probe, csi-driver-registrar, prepare-ovirt-config (init)
bash-4.4# ls /tmp/config
ovirt-config.yaml  ovirt-engine-ca.pem

```

**Using new image - Config file gone**
```
 kk exec -it -n ovirt-csi      ovirt-csi-node-plugin-z2dbm bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
Defaulted container "ovirt" out of: ovirt, liveness-probe, csi-driver-registrar, prepare-ovirt-config (init)
bash-4.4# ls /tmp/config
ovirt-engine-ca.pem

  kk exec -it -n ovirt-csi      ovirt-csi-controller-plugin-76cf454656-rt2kg bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
Defaulted container "ovirt" out of: ovirt, liveness-probe, csi-attacher, csi-provisioner, csi-resizer, prepare-ovirt-config (init)
bash-4.4# ls /tmp/config
ovirt-engine-ca.pem
```

**PVC test after re-creating pod**
```
kk exec -it test-csi bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
[root@test-csi /]# ls /paul
bin.txt  lost+found
[root@test-csi /]# cat /paul/bin.txt
[
alias
arch
awk
b2sum
base32
base64
...

```
