### PR TITLE
Fix intermittent CSI driver crash and remove clear text password from on-disk config file

### DIFF
--- a/buildrpm/ovirt-csi-driver-container-image.spec
+++ b/buildrpm/ovirt-csi-driver-container-image.spec
@@ -6,7 +6,7 @@
 
 %global app_name                ovirt-csi-driver
 %global app_version             4.20.0
-%global oracle_release_version  3
+%global oracle_release_version  4
 %global _buildhost              build-ol%{?oraclelinux}-%{?_arch}.oracle.com
 
 Name:           %{app_name}-container-image
@@ -43,6 +43,9 @@ podman save -o %{app_name}.tar %{docker_image}
 /usr/local/share/olcne/%{app_name}.tar
 
 %changelog
+* Wed Jun 25 2025 Paul Mackin <paul.mackin@oracle.com> - 4.20.0-4
+- Base64 encode password in config file.
+
 * Tue Jun 24 2025 Paul Mackin <paul.mackin@oracle.com> - 4.20.0-3
 - Delete config file containing password.
 

--- a/buildrpm/ovirt-csi-driver.spec
+++ b/buildrpm/ovirt-csi-driver.spec
@@ -6,7 +6,7 @@
 
 %global app_name                ovirt-csi-driver
 %global app_version             4.20.0
-%global oracle_release_version  3
+%global oracle_release_version  4
 %global _buildhost              build-ol%{?oraclelinux}-%{?_arch}.oracle.com
 
 Name:           %{app_name}
@@ -37,6 +37,9 @@ install -m 755 bin/%{app_name} %{buildroot}/%{app_name}
 /%{app_name}
 
 %changelog
+* Wed Jun 25 2025 Paul Mackin <paul.mackin@oracle.com> - 4.20.0-4
+- Base64 encode password in config file.
+
 * Tue Jun 24 2025 Paul Mackin <paul.mackin@oracle.com> - 4.20.0-3
 - Delete config file containing password.
 

--- a/internal/ovirt/ovirt.go
+++ b/internal/ovirt/ovirt.go
@@ -52,7 +52,7 @@ func NewClient() (ovirtclient.Client, error) {
 		logger,
 		nil,
 	)
-	
+
 	return client, nil
 }
 

--- a/internal/ovirt/ovirt.go
+++ b/internal/ovirt/ovirt.go
@@ -1,10 +1,12 @@
 package ovirt
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
+	"encoding/base64"
 	kloglogger "github.com/ovirt/go-ovirt-client-log-klog/v2"
 	ovirtclient "github.com/ovirt/go-ovirt-client/v2"
 	"gopkg.in/yaml.v2"
@@ -16,13 +18,23 @@ const defaultOvirtConfigEnvVar = "OVIRT_CONFIG"
 type Config struct {
 	URL      string `yaml:"ovirt_url"`
 	Username string `yaml:"ovirt_username"`
-	Password string `yaml:"ovirt_password"`
+	Password string `yaml:"ovirt_password,omitempty"`
+	Base64   string `yaml:"ovirt_base64,omitempty"`
 	CAFile   string `yaml:"ovirt_cafile,omitempty"`
 	Insecure bool   `yaml:"ovirt_insecure,omitempty"`
 }
 
 func NewClient() (ovirtclient.Client, error) {
 	ovirtConfig, err := GetOvirtConfig()
+	if err != nil {
+		return nil, fmt.Errorf("Error getting ovirt config: %v", err)
+	}
+
+	ovirtConfig, err = ensureBase64PasswordInConfig(ovirtConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	tls := ovirtclient.TLS()
 	if ovirtConfig.Insecure {
 		tls.Insecure()
@@ -102,4 +114,29 @@ func (c *Config) Save() error {
 
 	path := DiscoverConfigFilePath()
 	return ioutil.WriteFile(path, out, os.FileMode(0600))
+}
+
+// ensureBase64PasswordInConfig ensures that the password on disk is in base64
+func ensureBase64PasswordInConfig(config *Config) (*Config, error) {
+	pw := config.Password
+	if pw != "" {
+		// password is in clear text. Base64 encode it and remove the clear-text password.
+		pw = config.Password
+		config.Base64 = base64.StdEncoding.EncodeToString([]byte(pw))
+		config.Password = ""
+		if err := config.Save(); err != nil {
+			return nil, err
+		}
+	}
+	if config.Base64 == "" {
+		return nil, fmt.Errorf("Config file is missing both Password and PasswordBase64")
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(config.Base64)
+	if err != nil {
+		return nil, fmt.Errorf("Error decoding base64 password: %v", err)
+	}
+
+	config.Password = string(decoded)
+	return config, nil
 }

--- a/internal/ovirt/ovirt.go
+++ b/internal/ovirt/ovirt.go
@@ -52,17 +52,7 @@ func NewClient() (ovirtclient.Client, error) {
 		logger,
 		nil,
 	)
-	// remove config file regardless of the previous status
-	configPath := DiscoverConfigFilePath()
-	removeErr := os.Remove(configPath)
-	if removeErr != nil {
-		return nil, removeErr
-	}
-
-	// Check for any previous error
-	if err != nil {
-		return nil, err
-	}
+	
 	return client, nil
 }
 


### PR DESCRIPTION
The ovirt-csi-driver was crashing because ovirt container restart was broken.   It broke because the config file was deleted during startup.  As a result, a container restart was missing the config file.  Change the code keep the file, but
remove clear text password from the config file.  Replace the password field with the base64 encoded password.  Decode the password at runtime.

**Config file on both pods**
```
kk exec -it -n ovirt-csi       ovirt-csi-controller-plugin-76cf454656-j4dw6 bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
Defaulted container "ovirt" out of: ovirt, liveness-probe, csi-attacher, csi-provisioner, csi-resizer, prepare-ovirt-config (init)
bash-4.4# ls /tmp/config/
ovirt-config.yaml  ovirt-engine-ca.pem
bash-4.4# 
bash-4.4# cat /tmp/config/ovirt-config.yaml 
ovirt_url: <url>
ovirt_username: <username>
ovirt_base64: <encoded-pw>
ovirt_cafile: /tmp/config/ovirt-engine-ca.pem


> kk exec -it -n ovirt-csi      ovirt-csi-controller-plugin-76cf454656-j4dw6   bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
Defaulted container "ovirt" out of: ovirt, liveness-probe, csi-attacher, csi-provisioner, csi-resizer, prepare-ovirt-config (init)
bash-4.4# ls /tmp/config
ovirt-config.yaml  ovirt-engine-ca.pem
bash-4.4# cat /tmp/config/ovirt-config.yaml 
ovirt_url: <url>
ovirt_username:  <username>
ovirt_base64: <encoded-pw>
ovirt_cafile: /tmp/config/ovirt-engine-ca.pem
```

**Running pods**
```
ovirt-csi      ovirt-csi-controller-plugin-76cf454656-j4dw6       5/5     Running   2 (4m20s ago)   7m58s
ovirt-csi      ovirt-csi-node-plugin-p7ffc                        3/3     Running   0               5m30s
```