### PR TITLE
Add support for disk_profile usage in StorageClass

### DIFF
--- a/buildrpm/ovirt-csi-driver-container-image.spec
+++ b/buildrpm/ovirt-csi-driver-container-image.spec
@@ -5,8 +5,8 @@
 %endif
 
 %global app_name                ovirt-csi-driver
-%global app_version             4.20.0
-%global oracle_release_version  4
+%global app_version             4.21.1
+%global oracle_release_version  1
 %global _buildhost              build-ol%{?oraclelinux}-%{?_arch}.oracle.com
 
 Name:           %{app_name}-container-image
@@ -43,6 +43,9 @@ podman save -o %{app_name}.tar %{docker_image}
 /usr/local/share/olcne/%{app_name}.tar
 
 %changelog
+* Mond Jul 21 2025 Paul Mackin <paul.mackin@oracle.com> - 4.21.0-1
+- Update versions to 4.21.0 for disk_profile work for merging to master
+
 * Wed Jun 25 2025 Paul Mackin <paul.mackin@oracle.com> - 4.20.0-4
 - Base64 encode password in config file.
 

--- a/buildrpm/ovirt-csi-driver.spec
+++ b/buildrpm/ovirt-csi-driver.spec
@@ -5,8 +5,8 @@
 %endif
 
 %global app_name                ovirt-csi-driver
-%global app_version             4.20.0
-%global oracle_release_version  4
+%global app_version             4.21.0
+%global oracle_release_version  1
 %global _buildhost              build-ol%{?oraclelinux}-%{?_arch}.oracle.com
 
 Name:           %{app_name}
@@ -37,6 +37,9 @@ install -m 755 bin/%{app_name} %{buildroot}/%{app_name}
 /%{app_name}
 
 %changelog
+* Mon Jul 21 2025 Paul Mackin <paul.mackin@oracle.com> - 4.21.0-1
+- Update versions to 4.21.0 for disk_profile work for merging to master
+
 * Wed Jun 25 2025 Paul Mackin <paul.mackin@oracle.com> - 4.20.0-4
 - Base64 encode password in config file.
 

--- a/cmd/ovirt-csi-driver/ovirt-csi-driver.go
+++ b/cmd/ovirt-csi-driver/ovirt-csi-driver.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/ovirt/csi-driver/pkg/ovirt/ovclient"
 	"math/rand"
 	"os"
 	"time"
 
 	"github.com/ovirt/csi-driver/internal/ovirt"
+	ovconfig "github.com/ovirt/csi-driver/pkg/config"
 	"github.com/ovirt/csi-driver/pkg/service"
+
 	ovirtclient "github.com/ovirt/go-ovirt-client/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -39,6 +42,17 @@ func main() {
 }
 
 func handle() {
+
+	// Validate server connection
+	c, err := ovconfig.GetOvirtConfig()
+	if err != nil {
+		klog.Fatal(fmt.Errorf("failed to get ovirt config: %v", err))
+	}
+	ovclient.GetOVClient(c)
+	if err != nil {
+		klog.Fatal(fmt.Errorf("error creating ovclient: %v", err))
+	}
+
 	if service.VendorVersion == "" {
 		klog.Fatalf("VendorVersion must be set at compile time")
 	}

--- a/internal/ovirt/ovirt.go
+++ b/internal/ovirt/ovirt.go
@@ -2,37 +2,15 @@ package ovirt
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-
-	"encoding/base64"
+	"github.com/ovirt/csi-driver/pkg/config"
 	kloglogger "github.com/ovirt/go-ovirt-client-log-klog/v2"
 	ovirtclient "github.com/ovirt/go-ovirt-client/v2"
-	"gopkg.in/yaml.v2"
 )
 
-const defaultOvirtConfigEnvVar = "OVIRT_CONFIG"
-
-// Config holds oVirt api access details.
-type Config struct {
-	URL      string `yaml:"ovirt_url"`
-	Username string `yaml:"ovirt_username"`
-	Password string `yaml:"ovirt_password,omitempty"`
-	Base64   string `yaml:"ovirt_base64,omitempty"`
-	CAFile   string `yaml:"ovirt_cafile,omitempty"`
-	Insecure bool   `yaml:"ovirt_insecure,omitempty"`
-}
-
 func NewClient() (ovirtclient.Client, error) {
-	ovirtConfig, err := GetOvirtConfig()
+	ovirtConfig, err := config.GetOvirtConfig()
 	if err != nil {
 		return nil, fmt.Errorf("Error getting ovirt config: %v", err)
-	}
-
-	ovirtConfig, err = ensureBase64PasswordInConfig(ovirtConfig)
-	if err != nil {
-		return nil, err
 	}
 
 	tls := ovirtclient.TLS()
@@ -54,79 +32,4 @@ func NewClient() (ovirtclient.Client, error) {
 	)
 
 	return client, nil
-}
-
-// LoadOvirtConfig from the following location (first wins):
-// 1. OVIRT_CONFIG env variable
-// 2  $defaultOvirtConfigPath
-func LoadOvirtConfig() ([]byte, error) {
-	data, err := ioutil.ReadFile(DiscoverConfigFilePath())
-	if err != nil {
-		return nil, err
-	}
-	return data, nil
-}
-
-// GetOvirtConfig will return an Config by loading
-// the configuration from locations specified in @LoadOvirtConfig
-// error is return if the configuration could not be retained.
-func GetOvirtConfig() (*Config, error) {
-	c := Config{}
-	in, err := LoadOvirtConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	err = yaml.Unmarshal(in, &c)
-	if err != nil {
-		return nil, err
-	}
-
-	return &c, nil
-}
-
-func DiscoverConfigFilePath() string {
-	path, _ := os.LookupEnv(defaultOvirtConfigEnvVar)
-	if path != "" {
-		return path
-	}
-
-	return filepath.Join(os.Getenv("HOME"), ".ovirt", "ovirt-config.yaml")
-}
-
-// Save will serialize the config back into the locations
-// specified in @LoadOvirtConfig, first location with a file, wins.
-func (c *Config) Save() error {
-	out, err := yaml.Marshal(c)
-	if err != nil {
-		return err
-	}
-
-	path := DiscoverConfigFilePath()
-	return ioutil.WriteFile(path, out, os.FileMode(0600))
-}
-
-// ensureBase64PasswordInConfig ensures that the password on disk is in base64
-func ensureBase64PasswordInConfig(config *Config) (*Config, error) {
-	pw := config.Password
-	if pw != "" {
-		// password is in clear text. Base64 encode it and remove the clear-text password.
-		pw = config.Password
-		config.Base64 = base64.StdEncoding.EncodeToString([]byte(pw))
-		config.Password = ""
-		if err := config.Save(); err != nil {
-			return nil, err
-		}
-	}
-	if config.Base64 == "" {
-		return nil, fmt.Errorf("Config file is missing both Password and PasswordBase64")
-	}
-
-	decoded, err := base64.StdEncoding.DecodeString(config.Base64)
-	if err != nil {
-		return nil, fmt.Errorf("Error decoding base64 password: %v", err)
-	}
-
-	config.Password = string(decoded)
-	return config, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"encoding/base64"
+	"gopkg.in/yaml.v2"
+)
+
+const defaultOvirtConfigEnvVar = "OVIRT_CONFIG"
+
+// singleton config
+var ovconfig *Config
+
+// Config holds oVirt api access details.
+type Config struct {
+	URL      string `yaml:"ovirt_url"`
+	Username string `yaml:"ovirt_username"`
+	Password string `yaml:"ovirt_password,omitempty"`
+	Base64   string `yaml:"ovirt_base64,omitempty"`
+	CAFile   string `yaml:"ovirt_cafile,omitempty"`
+	Insecure bool   `yaml:"ovirt_insecure,omitempty"`
+}
+
+// GetOvirtConfig will return a Config by loading
+// it from disk and ensuring that the password on disk is base64 encoded.
+func GetOvirtConfig() (*Config, error) {
+	if ovconfig != nil {
+		return ovconfig, nil
+	}
+
+	ovirtConfig, err := getOvirtConfigFromDisk()
+	if err != nil {
+		return nil, fmt.Errorf("Error getting ovirt config: %v", err)
+	}
+
+	ovirtConfig, err = ensureBase64PasswordInConfig(ovirtConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	ovconfig = ovirtConfig
+	return ovirtConfig, nil
+}
+
+// getOvirtConfigFromFile will return a Config by loading
+// the configuration from locations specified in @LoadOvirtConfig
+// error is return if the configuration could not be retained.
+func getOvirtConfigFromDisk() (*Config, error) {
+	c := Config{}
+	in, err := loadOvirtConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	err = yaml.Unmarshal(in, &c)
+	if err != nil {
+		return nil, err
+	}
+
+	return &c, nil
+}
+
+// loadOvirtConfig from the following location (first wins):
+// 1. OVIRT_CONFIG env variable
+// 2  $defaultOvirtConfigPath
+func loadOvirtConfig() ([]byte, error) {
+	data, err := ioutil.ReadFile(discoverConfigFilePath())
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func discoverConfigFilePath() string {
+	path, _ := os.LookupEnv(defaultOvirtConfigEnvVar)
+	if path != "" {
+		return path
+	}
+
+	return filepath.Join(os.Getenv("HOME"), ".ovirt", "ovirt-config.yaml")
+}
+
+// Save will serialize the config back into the locations
+// specified in @LoadOvirtConfig, first location with a file, wins.
+func (c *Config) Save() error {
+	out, err := yaml.Marshal(c)
+	if err != nil {
+		return err
+	}
+
+	path := discoverConfigFilePath()
+	return ioutil.WriteFile(path, out, os.FileMode(0600))
+}
+
+// ensureBase64PasswordInConfig ensures that the password on disk is in base64
+func ensureBase64PasswordInConfig(config *Config) (*Config, error) {
+	pw := config.Password
+	if pw != "" {
+		// password is in clear text. Base64 encode it and remove the clear-text password.
+		pw = config.Password
+		config.Base64 = base64.StdEncoding.EncodeToString([]byte(pw))
+		config.Password = ""
+		if err := config.Save(); err != nil {
+			return nil, err
+		}
+	}
+	if config.Base64 == "" {
+		return nil, fmt.Errorf("Config file is missing both Password and PasswordBase64")
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(config.Base64)
+	if err != nil {
+		return nil, fmt.Errorf("Error decoding base64 password: %v", err)
+	}
+
+	config.Password = string(decoded)
+	return config, nil
+}

--- a/pkg/ovirt/diskprofile/policy.go
+++ b/pkg/ovirt/diskprofile/policy.go
@@ -1,0 +1,35 @@
+package diskprofile
+
+import (
+	"fmt"
+	"github.com/ovirt/csi-driver/pkg/ovirt/rest/storagedomain"
+	"strconv"
+)
+
+const PolicyLeastUsed = "leastUsed"
+
+// selectDomainUsingPolicy selects the best domain using the policy
+func selectDomainUsingPolicy(domains []*storagedomain.StorageDomain, policy string) (*storagedomain.StorageDomain, error) {
+	switch policy {
+	case PolicyLeastUsed:
+		return selectLeastUsed(domains)
+	default:
+		return selectLeastUsed(domains)
+	}
+}
+
+func selectLeastUsed(domains []*storagedomain.StorageDomain) (*storagedomain.StorageDomain, error) {
+	var selected *storagedomain.StorageDomain
+	var maxsize int64
+	for i, d := range domains {
+		size, err := strconv.ParseInt(d.Available, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse disk size: %w", err)
+		}
+		if size > maxsize {
+			selected = domains[i]
+			maxsize = size
+		}
+	}
+	return selected, nil
+}

--- a/pkg/ovirt/diskprofile/selector.go
+++ b/pkg/ovirt/diskprofile/selector.go
@@ -1,0 +1,91 @@
+package diskprofile
+
+import (
+	"fmt"
+	"github.com/ovirt/csi-driver/pkg/config"
+	"github.com/ovirt/csi-driver/pkg/ovirt/ovclient"
+	"github.com/ovirt/csi-driver/pkg/ovirt/rest/disk_profile"
+	"github.com/ovirt/csi-driver/pkg/ovirt/rest/storagedomain"
+	log "k8s.io/klog"
+)
+
+func SelectStorageDomainFromDiskProfile(config *config.Config, profileName string, policy string) (string, error) {
+	domains, err := getStorageDomainsFromDiskProfile(config, profileName)
+	if err != nil {
+		return "", err
+	}
+	if domains == nil {
+		return "", fmt.Errorf("No storage domains found for disk profile %s", profileName)
+	}
+
+	// filter out the domains that cannot be used
+	domains, err = getUseableDomains(domains)
+	if domains == nil {
+		return "", fmt.Errorf("No storage domains found with the acceptable external status")
+	}
+
+	domain, err := selectDomainUsingPolicy(domains, policy)
+	if err != nil {
+		return "", fmt.Errorf("Error selecting domain using policy %s: %s", policy, err.Error())
+	}
+	if domain == nil {
+		return "", fmt.Errorf("No storage domain selected for disk profile %s", profileName)
+	}
+
+	log.Infof("Selected storage domain %s for disk profile %s", domain.Name, profileName)
+	return domain.Name, nil
+}
+
+func getStorageDomainsFromDiskProfile(config *config.Config, diskProfileName string) ([]*storagedomain.StorageDomain, error) {
+	ovcli, err := ovclient.GetOVClient(config)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting ovirt client: %s", err.Error())
+	}
+
+	// get the disk profiles by name
+	diskProfiles, err := disk_profile.GetDiskProfilesByName(ovcli, diskProfileName)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting disk profiles by disk profile name %s: %s", diskProfileName, err.Error())
+	}
+
+	// get all storage domains
+	storageDomainList, err := storagedomain.GetStorageDomains(ovcli)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting storage domain list: %s", err.Error())
+	}
+
+	// create a map of storage domains by id
+	sdMap := make(map[string]*storagedomain.StorageDomain)
+	for i, sd := range storageDomainList.StorageDomains {
+		sdMap[sd.Id] = &storageDomainList.StorageDomains[i]
+	}
+
+	// build a list of storage domains where the domain is being used by a profile
+	sdList := []*storagedomain.StorageDomain{}
+	for _, dp := range diskProfiles {
+		sd, ok := sdMap[dp.StorageDomain.Id]
+		if !ok {
+			continue
+		}
+		sdList = append(sdList, sd)
+	}
+
+	// build the list of storage domains
+	return sdList, nil
+}
+
+// return domains that have external status == ok/info
+func getUseableDomains(domains []*storagedomain.StorageDomain) ([]*storagedomain.StorageDomain, error) {
+	results := []*storagedomain.StorageDomain{}
+	for i, d := range domains {
+		if d.ExternalStatus == storagedomain.ExternalStatusOK ||
+			d.ExternalStatus == storagedomain.ExternalStatusInfo {
+			results = append(results, domains[i])
+			log.Infof("Including storage domain %s in selection list", d.Name)
+		} else {
+			log.Infof("Ignoring storage domain %s. ExternalStatus is %s",
+				d.Name, d.ExternalStatus)
+		}
+	}
+	return results, nil
+}

--- a/pkg/ovirt/ovclient/ovclient.go
+++ b/pkg/ovirt/ovclient/ovclient.go
@@ -1,0 +1,178 @@
+// Copyright (c) 2024, 2025, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package ovclient
+
+import (
+	"fmt"
+	"github.com/ovirt/csi-driver/pkg/config"
+	"io/ioutil"
+	log "k8s.io/klog"
+	"net/http"
+	"net/url"
+	"strings"
+
+	ovhttp "github.com/ovirt/csi-driver/pkg/ovirt/rest/http"
+	"k8s.io/apimachinery/pkg/util/json"
+)
+
+type Credentials struct {
+	// Username is the OAuth2 username
+	Username string
+
+	// Password is the OAuth2 user password
+	Password string
+
+	// Scope is the OAuth2 scope
+	Scope string
+
+	// CA is the oVirt CA
+	CA map[string]string
+}
+
+type AuthData struct {
+	AccessToken string `json:"access_token"`
+}
+
+type Client struct {
+	// AccessToken is the REST bearer token
+	AccessToken string
+
+	// ApiServerURL is the endpoint to the oVirt API server
+	ApiServerURL string
+
+	// REST is the HTTP REST client used for the oVirt REST API
+	*ovhttp.REST
+
+	*Credentials
+
+	InsecureSkipTLSVerify bool
+}
+
+// GetOVClient gets an ovClient
+func GetOVClient(config *config.Config) (*Client, error) {
+	// validate the secret that has the oVirt REST creds
+	creds, err := getCredentials(config)
+	if err != nil {
+		return nil, err
+	}
+
+	if !config.Insecure {
+		caData, err := ioutil.ReadFile(config.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA file: %s", err.Error())
+		}
+		caString := strings.TrimSpace(string(caData))
+		creds.CA = map[string]string{"ca.crt": caString}
+	}
+
+	// Get an oVirt client
+	ovcli, err := ensureOvClient(creds, config.URL, config.Insecure)
+	if err != nil {
+		return nil, err
+	}
+
+	return ovcli, nil
+}
+
+// ensureOvClient ensures that we have an access token that can be used with the oVirt REST API.
+func ensureOvClient(creds *Credentials, apiServerURL string, insecureSkipTLSVerify bool) (*Client, error) {
+	// strip the /api if it exists since this code will append it
+	url := strings.TrimRight(apiServerURL, "/api")
+
+	// Create a new client and validate that it works
+	ovcli := &Client{
+		ApiServerURL:          url,
+		Credentials:           creds,
+		InsecureSkipTLSVerify: insecureSkipTLSVerify,
+	}
+
+	if err := ovcli.ensureAccessToken(); err != nil {
+		return nil, err
+	}
+
+	// Validate the token by getting system information
+	const path = "/api"
+
+	// call the server to get the datacenters just to verify the REST API works.
+	body, err := ovcli.REST.Get(ovcli.AccessToken, path)
+	if err != nil {
+		err = fmt.Errorf("Error calling HTTP GET for URL %s: %v", ovcli.ApiServerURL, err)
+		log.Error(err)
+		return nil, err
+	}
+	if len(body) == 0 {
+		err = fmt.Errorf("No system data found at %v", ovcli.ApiServerURL)
+		log.Error(err)
+		return nil, err
+	}
+
+	return ovcli, nil
+}
+
+// ensureAccessToken ensures that the access token exists
+func (o *Client) ensureAccessToken() error {
+	const tokenPath = "/sso/oauth/token"
+
+	if o.AccessToken != "" {
+		return nil
+	}
+
+	o.REST = ovhttp.NewRestClient(o, o.ApiServerURL, o.CA, o.InsecureSkipTLSVerify)
+
+	// create the payload to send using POST
+	d := url.Values{}
+	d.Set("username", o.Credentials.Username)
+	d.Set("password", o.Credentials.Password)
+	d.Set("scope", "ovirt-app-api")
+	d.Set("grant_type", "password")
+
+	// call the server to get the access token
+	h := &http.Header{}
+	o.REST.HeaderUrlEncoded(h)
+	o.REST.HeaderAcceptJSON(h)
+	// path string, payload io.Reader, header *rest.Header
+	body, _, err := o.REST.Post(tokenPath, strings.NewReader(d.Encode()), h)
+	if err != nil {
+		err = fmt.Errorf("Error doing HTTP POST to oVirt server: %v", err)
+		return err
+	}
+	if len(body) == 0 {
+		err = fmt.Errorf("Error doing HTTP POST to create access token.  No body returned by server: %v", err)
+		return err
+	}
+
+	// extract access token from results
+	ad := &AuthData{}
+	if err = json.Unmarshal(body, ad); err != nil {
+		err = fmt.Errorf("Error UnMarshalling JSON for credentials: %v", err)
+		return err
+	}
+
+	o.AccessToken = ad.AccessToken
+	if o.AccessToken == "" {
+		err = fmt.Errorf("Access token missing from body returned by POST")
+		return err
+	}
+
+	return nil
+}
+
+// ClearAccessToken is called when there is a REST HTTP error
+func (o *Client) ClearAccessToken() {
+	o.AccessToken = ""
+}
+
+func getCredentials(config *config.Config) (*Credentials, error) {
+	c := Credentials{}
+
+	c.Username = config.Username
+	if c.Username == "" {
+		return nil, fmt.Errorf("Config is missing OLVM username")
+	}
+	c.Password = config.Password
+	if c.Password == "" {
+		return nil, fmt.Errorf("Config is missing OLVM password")
+	}
+	return &c, nil
+}

--- a/pkg/ovirt/rest/disk_profile/get.go
+++ b/pkg/ovirt/rest/disk_profile/get.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package disk_profile
+
+import (
+	"fmt"
+	"github.com/ovirt/csi-driver/pkg/ovirt/ovclient"
+	"k8s.io/apimachinery/pkg/util/json"
+	log "k8s.io/klog"
+	"strings"
+)
+
+// GetDiskProfiles gets all disk profiles.
+func GetDiskProfiles(ovcli *ovclient.Client) (*DiskProfileList, error) {
+	const path = "/api/diskprofiles"
+
+	// call the server
+	body, err := ovcli.REST.Get(ovcli.AccessToken, path)
+	if err != nil {
+		err = fmt.Errorf("Error doing HTTP GET: %v", err)
+		return nil, err
+	}
+
+	diskProfileList := &DiskProfileList{}
+	err = json.Unmarshal(body, diskProfileList)
+	if err != nil {
+		err = fmt.Errorf("Error unmarshaling StorageDomains: %v", err)
+		log.Error(err)
+		return nil, err
+	}
+
+	return diskProfileList, nil
+}
+
+// GetDiskGetDiskProfilesByName gets a list disk profile by name
+func GetDiskProfilesByName(ovcli *ovclient.Client, profileName string) ([]*DiskProfile, error) {
+	matchList := []*DiskProfile{}
+
+	profileList, err := GetDiskProfiles(ovcli)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, sd := range profileList.DiskProfiles {
+		if strings.EqualFold(sd.Name, profileName) {
+			matchList = append(matchList, &profileList.DiskProfiles[i])
+		}
+	}
+
+	return matchList, nil
+}

--- a/pkg/ovirt/rest/disk_profile/types.go
+++ b/pkg/ovirt/rest/disk_profile/types.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package disk_profile
+
+const (
+	StatusOK = "ok"
+
+	FormatCow = "cow"
+
+	BackupNone = "none"
+)
+
+type DiskProfileList struct {
+	DiskProfiles []DiskProfile `json:"disk_profile"`
+}
+
+type DiskProfile struct {
+	StorageDomain struct {
+		Href string `json:"href"`
+		Id   string `json:"id"`
+	} `json:"storage_domain"`
+	Name string `json:"name"`
+	Link []struct {
+		Href string `json:"href"`
+		Rel  string `json:"rel"`
+	} `json:"link"`
+	Href string `json:"href"`
+	Id   string `json:"id"`
+}

--- a/pkg/ovirt/rest/http/delete.go
+++ b/pkg/ovirt/rest/http/delete.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package http
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Delete deletes a REST resource
+func (r REST) Delete(path string, header *http.Header) (int, error) {
+	statusCode, err := r.deletePriv(path, header)
+	if err != nil {
+		r.tokenResetter.ClearAccessToken()
+	}
+	return statusCode, err
+}
+
+// deletePriv deletes a REST resource
+func (r REST) deletePriv(path string, header *http.Header) (int, error) {
+	URL := resolveURL(r.endpointURL, path)
+
+	req, err := http.NewRequest("DELETE", URL, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	req.Header = *header
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	if resp == nil {
+		return 0, fmt.Errorf("HTTP DELETE to endpoint %s received a nil response", URL)
+	}
+
+	defer resp.Body.Close()
+
+	// 204 Success but no data from server
+	if resp.StatusCode == 204 {
+		return resp.StatusCode, nil
+	}
+
+	// Always the body, it may have an error message
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		if resp.StatusCode > 204 {
+			return resp.StatusCode, fmt.Errorf("HTTP DELETE to %s returned status code  %d", URL, resp.StatusCode)
+		}
+		return resp.StatusCode, err
+	}
+
+	// Body was read ok but there is a response code error
+	if resp.StatusCode > 204 {
+		return resp.StatusCode, fmt.Errorf("HTTP DELETE to %s returned status code %d.  Error Message: %s", URL, resp.StatusCode, body)
+	}
+
+	return resp.StatusCode, nil
+}

--- a/pkg/ovirt/rest/http/get.go
+++ b/pkg/ovirt/rest/http/get.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package http
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func (r REST) Get(accessToken string, path string) ([]byte, error) {
+	body, err := r.getPriv(accessToken, path)
+	if err != nil {
+		r.tokenResetter.ClearAccessToken()
+	}
+	return body, err
+}
+
+func (r REST) getPriv(accessToken string, path string) ([]byte, error) {
+	URL := resolveURL(r.endpointURL, path)
+
+	req, err := http.NewRequest("GET", URL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("HTTP GET to %s returned a nil response", URL)
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("HTTP GET to %s returned status code  %d", URL, resp.StatusCode)
+	}
+
+	defer resp.Body.Close()
+
+	// Read the data
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}

--- a/pkg/ovirt/rest/http/httpclient.go
+++ b/pkg/ovirt/rest/http/httpclient.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2024, 2025, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package http
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Ensure Worker implements SPI interface
+var _ HeaderAdder = &REST{}
+
+type TokenResetter interface {
+	ClearAccessToken()
+}
+
+type HeaderAdder interface {
+	HeaderAcceptJSON(header *http.Header)
+	HeaderContentJSON(header *http.Header)
+	HeaderContentXML(header *http.Header)
+	HeaderUrlEncoded(header *http.Header)
+	HeaderBearerToken(header *http.Header, token string)
+}
+
+type REST struct {
+	endpointURL   string
+	client        *http.Client
+	tokenResetter TokenResetter
+}
+
+func NewRestClient(resetter TokenResetter, endpointURL string, caMap map[string]string, insecureSkipTLSVerify bool) *REST {
+	// Create Transport object
+	tr := &http.Transport{
+		TLSClientConfig:       &tls.Config{RootCAs: rootCertPool(caMap), InsecureSkipVerify: insecureSkipTLSVerify},
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	client := &http.Client{Transport: tr}
+	return &REST{
+		endpointURL:   endpointURL,
+		client:        client,
+		tokenResetter: resetter,
+	}
+}
+
+func (r REST) HeaderAcceptJSON(header *http.Header) {
+	header.Set("Accept", "application/json")
+}
+
+func (r REST) HeaderContentOctet(header *http.Header) {
+	header.Set("Content-Type", "application/octet-stream")
+}
+
+func (r REST) HeaderContentJSON(header *http.Header) {
+	header.Set("Content-Type", "application/json")
+}
+
+func (r REST) HeaderContentXML(header *http.Header) {
+	header.Set("Content-Type", "application/xml")
+}
+
+func (r REST) HeaderUrlEncoded(header *http.Header) {
+	header.Set("Content-Type", "application/x-www-form-urlencoded")
+}
+
+func (r REST) HeaderBearerToken(header *http.Header, token string) {
+	header.Set("Authorization", "Bearer "+token)
+}
+
+func (r REST) HeaderContentLen(header *http.Header, len int64) {
+	lenstr := fmt.Sprintf("%v", len)
+	header.Set("Content-Length", lenstr)
+}
+
+func (r REST) HeaderContentRange(header *http.Header, start int64, end int64, totalLen int64) {
+	s := fmt.Sprintf("bytes %v-%v/%v", start, end, totalLen)
+	header.Set("Content-Range", s)
+}
+
+func (r REST) HeaderNoCache(header *http.Header) {
+	header.Set("Cache-Control'", "no-cache")
+	header.Set("Pragma", "no-cache")
+}
+
+func rootCertPool(caMap map[string]string) *x509.CertPool {
+	if len(caMap) == 0 {
+		return nil
+	}
+
+	// if we have caData, use it
+	certPool := x509.NewCertPool()
+
+	// Create CA cert pool
+	for _, cert := range caMap {
+		certPool.AppendCertsFromPEM([]byte(cert))
+	}
+	return certPool
+}
+
+func resolveURL(endpoint string, path string) string {
+	var URL string
+	if strings.HasPrefix(endpoint, "https://") {
+		URL = fmt.Sprintf("%s%s", endpoint, path)
+	} else {
+		URL = fmt.Sprintf("https://%s%s", endpoint, path)
+	}
+	URL = strings.TrimSuffix(URL, "/")
+	return URL
+}

--- a/pkg/ovirt/rest/http/post.go
+++ b/pkg/ovirt/rest/http/post.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package http
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Post posts an HTTP request and returns the body, status code, and an error
+func (r REST) Post(path string, payload io.Reader, header *http.Header) ([]byte, int, error) {
+	body, statusCode, err := r.postPriv(path, payload, header)
+	if err != nil {
+		r.tokenResetter.ClearAccessToken()
+	}
+	return body, statusCode, err
+}
+
+// postPriv posts an HTTP request and returns the body, status code, and an error
+func (r REST) postPriv(path string, payload io.Reader, header *http.Header) ([]byte, int, error) {
+	URL := resolveURL(r.endpointURL, path)
+
+	req, err := http.NewRequest("POST", URL, payload)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	req.Header = *header
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	if resp == nil {
+		return nil, 0, fmt.Errorf("HTTP POST to %s returned a nil response", URL)
+	}
+
+	defer resp.Body.Close()
+
+	// 204 Success but no data from server
+	if resp.StatusCode == 204 {
+		return nil, 204, nil
+	}
+
+	// Always the body, it may have an error message
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		if resp.StatusCode > 204 {
+			return body, resp.StatusCode, fmt.Errorf("HTTP POST to %s returned status code  %d", URL, resp.StatusCode)
+		}
+		return nil, resp.StatusCode, err
+	}
+
+	// Body was read ok but there is a response code error
+	if resp.StatusCode > 204 {
+		return body, resp.StatusCode, fmt.Errorf("HTTP POST to %s returned status code %d.  Error Message: %s", URL, resp.StatusCode, body)
+	}
+
+	return body, resp.StatusCode, nil
+}

--- a/pkg/ovirt/rest/http/put.go
+++ b/pkg/ovirt/rest/http/put.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package http
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// PutAbsURL puts an HTTP request and returns the body, status code, and an error
+func (r REST) PutAbsURL(URL string, payload io.Reader, header *http.Header, contentLen int64) ([]byte, int, error) {
+	body, statusCode, err := r.putPriv(URL, payload, header, contentLen)
+	if err != nil {
+		r.tokenResetter.ClearAccessToken()
+	}
+	return body, statusCode, err
+}
+
+// putPriv puts an HTTP request and returns the body, status code, and an error
+func (r REST) putPriv(URL string, payload io.Reader, header *http.Header, contentLen int64) ([]byte, int, error) {
+	req, err := http.NewRequest("PUT", URL, payload)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	req.Header = *header
+	req.ContentLength = contentLen
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	if resp == nil {
+		return nil, 0, fmt.Errorf("HTTP PUT to %s returned a nil response", URL)
+	}
+
+	defer resp.Body.Close()
+
+	// 204 Success but no data from server
+	if resp.StatusCode == 204 {
+		return nil, 204, nil
+	}
+
+	// Always the body, it may have an error message
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		if resp.StatusCode > 204 {
+			return body, resp.StatusCode, fmt.Errorf("HTTP PUT to %s returned status code  %d", URL, resp.StatusCode)
+		}
+		return nil, resp.StatusCode, err
+	}
+
+	// Body was read ok but there is a response code error
+	if resp.StatusCode > 204 {
+		return body, resp.StatusCode, fmt.Errorf("HTTP PUT to %s returned status code %d.  Error Message: %s", URL, resp.StatusCode, body)
+	}
+
+	return body, resp.StatusCode, nil
+}

--- a/pkg/ovirt/rest/storagedomain/get.go
+++ b/pkg/ovirt/rest/storagedomain/get.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package storagedomain
+
+import (
+	"fmt"
+	"github.com/ovirt/csi-driver/pkg/ovirt/ovclient"
+	"k8s.io/apimachinery/pkg/util/json"
+	log "k8s.io/klog"
+)
+
+// GetStorageDomains gets all datacenters.
+func GetStorageDomains(ovcli *ovclient.Client) (*StorageDomainList, error) {
+	const path = "/api/storagedomains"
+
+	// call the server to get the datacenters
+	body, err := ovcli.REST.Get(ovcli.AccessToken, path)
+	if err != nil {
+		err = fmt.Errorf("Error doing HTTP GET: %v", err)
+		return nil, err
+	}
+
+	sdList := &StorageDomainList{}
+	err = json.Unmarshal(body, sdList)
+	if err != nil {
+		err = fmt.Errorf("Error unmarshaling StorageDomains: %v", err)
+		log.Error(err)
+		return nil, err
+	}
+
+	return sdList, nil
+}
+
+// GetStorageDomain gets a storage domain by name
+func GetStorageDomain(ovcli *ovclient.Client, storageDomainName string) (*StorageDomain, error) {
+	sdList, err := GetStorageDomains(ovcli)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, sd := range sdList.StorageDomains {
+		if sd.Name == storageDomainName {
+			return &sdList.StorageDomains[i], nil
+		}
+	}
+
+	return nil, fmt.Errorf("Storage Domain %s not found", storageDomainName)
+}

--- a/pkg/ovirt/rest/storagedomain/types.go
+++ b/pkg/ovirt/rest/storagedomain/types.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package storagedomain
+
+const (
+	ExternalStatusOK   = "ok"
+	ExternalStatusInfo = "info"
+
+	StatusActive = "active"
+)
+
+type StorageDomain struct {
+	Available                  string `json:"available,omitempty"`
+	Backup                     string `json:"backup"`
+	BlockSize                  string `json:"block_size"`
+	Committed                  string `json:"committed"`
+	CriticalSpaceActionBlocker string `json:"critical_space_action_blocker"`
+	DiscardAfterDelete         string `json:"discard_after_delete"`
+	ExternalStatus             string `json:"external_status"`
+	Master                     string `json:"master"`
+	Storage                    struct {
+		Type        string `json:"type"`
+		VolumeGroup struct {
+			LogicalUnits struct {
+				LogicalUnit []struct {
+					DiscardMaxSize    string `json:"discard_max_size"`
+					DiscardZeroesData string `json:"discard_zeroes_data"`
+					LunMapping        string `json:"lun_mapping"`
+					Paths             string `json:"paths"`
+					ProductId         string `json:"product_id"`
+					Serial            string `json:"serial"`
+					Size              string `json:"size"`
+					StorageDomainId   string `json:"storage_domain_id"`
+					VendorId          string `json:"vendor_id"`
+					VolumeGroupId     string `json:"volume_group_id"`
+					Id                string `json:"id"`
+				} `json:"logical_unit"`
+			} `json:"logical_units"`
+			Id string `json:"id"`
+		} `json:"volume_group,omitempty"`
+	} `json:"storage"`
+	StorageFormat             string `json:"storage_format"`
+	SupportsDiscard           string `json:"supports_discard"`
+	SupportsDiscardZeroesData string `json:"supports_discard_zeroes_data"`
+	Type                      string `json:"type"`
+	Used                      string `json:"used,omitempty"`
+	WarningLowSpaceIndicator  string `json:"warning_low_space_indicator"`
+	WipeAfterDelete           string `json:"wipe_after_delete"`
+	DataCenters               struct {
+		DataCenter []struct {
+			Href string `json:"href"`
+			Id   string `json:"id"`
+		} `json:"data_center"`
+	} `json:"data_centers,omitempty"`
+	Actions struct {
+		Link []struct {
+			Href string `json:"href"`
+			Rel  string `json:"rel"`
+		} `json:"link"`
+	} `json:"actions"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Comment     string `json:"comment"`
+	Link        []struct {
+		Href string `json:"href"`
+		Rel  string `json:"rel"`
+	} `json:"link"`
+	Href   string `json:"href"`
+	Id     string `json:"id"`
+	Status string `json:"status,omitempty"`
+}
+
+type StorageDomainList struct {
+	StorageDomains []StorageDomain `json:"storage_domain"`
+}

--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"fmt"
+	"github.com/ovirt/csi-driver/pkg/config"
+	"github.com/ovirt/csi-driver/pkg/ovirt/diskprofile"
 	"strconv"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -13,9 +15,11 @@ import (
 )
 
 const (
-	ParameterStorageDomainName = "storageDomainName"
-	ParameterThinProvisioning  = "thinProvisioning"
-	minimumDiskSize            = 1 * 1024 * 1024
+	ParameterDiskProfileName              = "diskProfileName"
+	ParameterStorageDomainSelectionPolicy = "storageDomainSelectionPolicy"
+	ParameterStorageDomainName            = "storageDomainName"
+	ParameterThinProvisioning             = "thinProvisioning"
+	minimumDiskSize                       = 1 * 1024 * 1024
 )
 
 // ControllerService implements the controller interface
@@ -32,10 +36,13 @@ var ControllerCaps = []csi.ControllerServiceCapability_RPC_Type{
 // CreateVolume creates the disk for the request, unattached from any VM
 func (c *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	klog.Infof("Creating disk %s", req.Name)
-	storageDomainName := req.Parameters[ParameterStorageDomainName]
-	if len(storageDomainName) == 0 {
-		return nil, fmt.Errorf("error required storageClass paramater %s wasn't set",
-			ParameterStorageDomainName)
+
+	storageDomainName, err := getStorageDomainName(req)
+	if err != nil {
+		return nil, err
+	}
+	if storageDomainName == "" {
+		return nil, fmt.Errorf("error: unable to determine storage domain name")
 	}
 	diskName := req.Name
 	if len(diskName) == 0 {
@@ -373,4 +380,31 @@ func (c *ControllerService) ControllerGetCapabilities(context.Context, *csi.Cont
 		)
 	}
 	return &csi.ControllerGetCapabilitiesResponse{Capabilities: caps}, nil
+}
+
+func getStorageDomainName(req *csi.CreateVolumeRequest) (string, error) {
+	storageDomainName := req.Parameters[ParameterStorageDomainName]
+	diskProfileName := req.Parameters[ParameterDiskProfileName]
+	policy := req.Parameters[ParameterStorageDomainSelectionPolicy]
+	if len(storageDomainName) > 0 && len(diskProfileName) > 0 {
+		return "", fmt.Errorf("error: you cannot specify both storageDomainName and diskProfileName")
+	}
+
+	if len(storageDomainName) > 0 {
+		klog.Infof("using storageDomainName %s", storageDomainName)
+		return storageDomainName, nil
+	}
+
+	if len(diskProfileName) == 0 {
+		return "", fmt.Errorf("error: you must specify either storageDomainName or diskProfileName")
+	}
+
+	klog.Infof("finding a storageDomain for disk profile %s", diskProfileName)
+
+	ovconfig, err := config.GetOvirtConfig()
+	if err != nil {
+		return "", fmt.Errorf("error getting ovirt config: %v", err)
+	}
+	sdName, err := diskprofile.SelectStorageDomainFromDiskProfile(ovconfig, diskProfileName, policy)
+	return sdName, err
 }


### PR DESCRIPTION
Add support for disk_profile usage in StorageClass allowing disk to be allocated from a list of OVM storage domains.  When the controller gets a request to allocate storage, it calls the OLVM API to get all the instances of disk_profiles that match the StorageClass diskProfile field.  The controller also gets the lists of storage domains.  Then the controller picks the storage domain that has the most space remaining.   The disk will be allocated from that storage domain.